### PR TITLE
Signature Image and Type should not be required

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Required fields denoted with *
 * Field Type: String
 * ISO-8061 Complient Time Stamp
 
-#### Signature Image*
+#### Signature Image
 * Field Name: **signatureImage**
 * Field Type: String
 * Base64 Encoded Image
 
-#### Signature Image Type*
+#### Signature Image Type
 * Field Name: **signatureImageType**
 * Field Type: String
 * Type prefix for Base64 Encoded Image


### PR DESCRIPTION
In reviewing this proposed standard GlobalVetLINK does not think the `signatureImage` and `signatureImageType` should be required as they do not communicate any crucial or even meaningful information when it comes to some forms of valid electronic signatures.