### PR TITLE
change premises name to animalPremises for better clarity of meaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Required fields denoted with *
 * Field Type: String
 
 ******
-## Premises
-* The following fields are enclosed in the **premise** array of objects
+## Animal Premises
+* The following fields are enclosed in the **animalPremises** array of objects
 * Note: multiple premises can be specified.
 
 #### Name

--- a/vfd.json
+++ b/vfd.json
@@ -38,7 +38,7 @@
         "phone": "8058013323",
         "fax": "8058013322"
     },
-    "premises": [{
+    "animalPremises": [{
         "name": "Full Premise Name",
         "ID": "National Premise ID",
         "address": "1234 Example Ln",


### PR DESCRIPTION
I know premises has a specific meaning in the animal health world, but it is such an otherwise vague term that it is hard for many developers who would potentially be filling in and reading this data format to understand its meaning. I think it should be animalPremises or animalLocations instead. 